### PR TITLE
Fix spacebar issues (basic room layout)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,6 +5,15 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  height: 100%;
+  overflow: hidden;
+}
+
+.phx-connected {
+  height: 100%;
+}
+
 /* Alerts and form errors used by phx.new */
 .alert {
   padding: 15px;

--- a/lib/cuberacer_live_web/live/game_live/components.ex
+++ b/lib/cuberacer_live_web/live/game_live/components.ex
@@ -1,6 +1,10 @@
 defmodule CuberacerLive.GameLive.Components do
   use Phoenix.Component
 
+  alias CuberacerLive.Sessions
+  alias CuberacerLive.Sessions.Round
+  alias CuberacerLive.Accounts.User
+
   def timer(assigns) do
     ~H"""
     <div
@@ -25,7 +29,7 @@ defmodule CuberacerLive.GameLive.Components do
 
   def chat(assigns) do
     ~H"""
-    <div id="chat" class="border" x-data="{
+    <div id="chat" class="flex flex-col w-80 border" x-data="{
       message: '',
 
       sendMessage() {
@@ -35,28 +39,70 @@ defmodule CuberacerLive.GameLive.Components do
         });
       }
     }">
-      <div class="h-44 flex flex-col-reverse overflow-auto">
-        <div id="room-messages" phx-update="append">
+      <div class="flex-1 flex flex-col-reverse overflow-auto">
+        <div id="room-messages" phx-update="append" class="divide-y">
           <%= for room_message <- @room_messages do %>
-            <div id={"room-message-#{room_message.id}"} class="h-8 t_room-message">
+            <div id={"room-message-#{room_message.id}"} class="t_room-message">
               <%= CuberacerLive.Messaging.display_room_message(room_message) %>
             </div>
           <% end %>
         </div>
       </div>
 
-      <input
-        id="chat-input"
-        type="text"
-        class="border"
-        x-model="message"
-        x-on:focus="$store.inputFocused = true"
-        x-on:blur="$store.inputFocused = false"
-        x-on:keydown.enter="sendMessage"
-        phx-hook="ChatInput"
-      />
-      <button @click="sendMessage">Send</button>
+      <div class="flex flex-row">
+        <input
+          id="chat-input"
+          type="text"
+          class="flex-1 border"
+          x-model="message"
+          x-on:focus="$store.inputFocused = true"
+          x-on:blur="$store.inputFocused = false"
+          x-on:keydown.enter="sendMessage"
+          phx-hook="ChatInput"
+        />
+        <button @click="sendMessage">Send</button>
+      </div>
     </div>
     """
+  end
+
+  def times_table(assigns) do
+    ~H"""
+    <div id="times-table" class="flex flex-col my-4">
+      <table class="divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <%= for user <- @present_users do %>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <%= user.email%>
+                <%= if user.id == @current_user.id do %>
+                  <span> (you)</span>
+                <% end %>
+              </th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody id="times-table-body" class="bg-white divide-y divide-gray-200" phx-update="prepend">
+          <%= for round <- @rounds do %>
+            <tr id={"round-#{round.id}"} class="t_round-row">
+              <%= for user <- @present_users do %>
+                <td id={"round-#{round.id}-solve-user-#{user.id}"} class="px-6 py-4 whitespace-nowrap">
+                  <div class="ml-4">
+                    <div class="text-sm font-medium text-gray-900">
+                      <%= Sessions.display_solve(user_solve_for_round(user, round)) %>
+                    </div>
+                  </div>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  defp user_solve_for_round(%User{} = user, %Round{} = round) do
+    Enum.find(round.solves, fn solve -> solve.user_id == user.id end)
   end
 end

--- a/lib/cuberacer_live_web/live/game_live/room.ex
+++ b/lib/cuberacer_live_web/live/game_live/room.ex
@@ -5,8 +5,6 @@ defmodule CuberacerLiveWeb.GameLive.Room do
   import CuberacerLive.GameLive.Components
 
   alias CuberacerLive.{Sessions, Cubing, Accounts, Messaging}
-  alias CuberacerLive.Accounts.User
-  alias CuberacerLive.Sessions.Round
   alias CuberacerLiveWeb.Presence
 
   @endpoint CuberacerLiveWeb.Endpoint
@@ -76,10 +74,6 @@ defmodule CuberacerLiveWeb.GameLive.Room do
   defp fetch_room_messages(socket) do
     room_messages = Messaging.list_room_messages(socket.assigns.session)
     assign(socket, room_messages: room_messages)
-  end
-
-  defp user_solve_for_round(%User{} = user, %Round{} = round) do
-    Enum.find(round.solves, fn solve -> solve.user_id == user.id end)
   end
 
   @impl true

--- a/lib/cuberacer_live_web/live/game_live/room.html.heex
+++ b/lib/cuberacer_live_web/live/game_live/room.html.heex
@@ -1,49 +1,21 @@
-<h1 class="text-xl font-bold"><%= @session.name %></h1>
+<div class="flex flex-row h-full">
+  <div class="flex-1 flex flex-col">
+    <div class="flex-1">
+      <h1 class="text-xl font-bold"><%= @session.name %></h1>
 
-<div class="my-3">
-  <span class="t_scramble"><%= current_scramble(@rounds) %></span>
-  <.timer />
-  <.penalty_input />
-</div>
-
-<button id="new-round-button" phx-click="new-round" class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">New round</button>
-
-<div id="times-table" class="flex flex-col my-4 h-72 overflow-scroll">
-  <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-      <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <%= for user <- @present_users do %>
-                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  <%= user.email%>
-                  <%= if user.id == @current_user.id do %>
-                    <span> (you)</span>
-                  <% end %>
-                </th>
-              <% end %>
-            </tr>
-          </thead>
-          <tbody id="times-table-body" class="bg-white divide-y divide-gray-200" phx-update="prepend">
-            <%= for round <- @rounds do %>
-              <tr id={"round-#{round.id}"} class="t_round-row">
-                <%= for user <- @present_users do %>
-                  <td id={"round-#{round.id}-solve-user-#{user.id}"} class="px-6 py-4 whitespace-nowrap">
-                    <div class="ml-4">
-                      <div class="text-sm font-medium text-gray-900">
-                        <%= Sessions.display_solve(user_solve_for_round(user, round)) %>
-                      </div>
-                    </div>
-                  </td>
-                <% end %>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+      <div class="my-3">
+        <span class="t_scramble"><%= current_scramble(@rounds) %></span>
+        <.timer />
+        <.penalty_input />
       </div>
+
+      <button id="new-round-button" phx-click="new-round" class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700">New round</button>
+    </div>
+
+    <div class="h-60 overflow-scroll">
+      <.times_table present_users={@present_users} rounds={@rounds} current_user={@current_user} />
     </div>
   </div>
-</div>
 
-<.chat room_messages={@room_messages} />
+  <.chat room_messages={@room_messages} />
+</div>

--- a/lib/cuberacer_live_web/templates/layout/live.html.heex
+++ b/lib/cuberacer_live_web/templates/layout/live.html.heex
@@ -1,4 +1,4 @@
-<main class="container mx-auto">
+<main class="h-full">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"
     phx-value-key="info"><%= live_flash(@flash, :info) %></p>

--- a/lib/cuberacer_live_web/templates/layout/root.html.heex
+++ b/lib/cuberacer_live_web/templates/layout/root.html.heex
@@ -10,10 +10,14 @@
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>
   <body>
-    <header>
-      <%= render "_navbar.html", assigns %>
-    </header>
+    <div class="flex flex-col h-full">
+      <header>
+        <%= render "_navbar.html", assigns %>
+      </header>
 
-    <%= @inner_content %>
+      <div class="flex-1 overflow-auto">
+        <%= @inner_content %>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
There were 2 spacebar issues:
1. After clicking "New Round", keyup on spacebar for timer would press the button again, creating another new round
2. Keydown on spacebar would scroll the page

Fixes:
1. `.prevent` on event listener for spacebar keyup
2. Make fixed height layout to prevent scrolling, because that is desired anyways, and `.prevent` on keydown prevents spaces from being typed in the chatbox.

------------
I struggled for a long time trying to get the chat box to only fill the rest of the screen and not expand to the size of the screen itself. This StackOverflow thread saved me: https://stackoverflow.com/questions/32640224