### PR TITLE
Get rid of WCA ID and birthday settings inputs

### DIFF
--- a/lib/cuberacer_live_web/templates/user_settings/_profile.html.heex
+++ b/lib/cuberacer_live_web/templates/user_settings/_profile.html.heex
@@ -23,22 +23,9 @@
     <%= error_tag f, :bio %>
 
     <div class="mt-3">
-      <%= label f, :wca_id, "WCA ID" %>
-      <%= text_input f, :wca_id, required: false, class: input_classes() %>
-      <%= error_tag f, :wca_id %>
-    </div>
-
-    <div class="mt-3">
       <%= label f, :country %>
       <%= select f, :country, CountryUtils.countries_select_options(), required: false, class: input_classes() %>
       <%= error_tag f, :country %>
-    </div>
-
-    <div class="mt-3">
-      <%= label f, :birthday %>
-      <div class="text-gray-500">This will display your current age on your profile.</div>
-      <%= date_input f, :birthday, required: false, class: input_classes() %>
-      <%= error_tag f, :birthday %>
     </div>
 
     <div class="mt-4">


### PR DESCRIPTION
This does not get rid of the settings themselves. The controller still allows them to be set, and in fact the tests don't even break, because they rely on sending data to the controller rather than entering it through the view, which would break since the form fields are no longer there.

This is a temporary solution while OAuth support for WCA IDs is in the works. I might just fully get rid of birthday, because even though I remember it being fun from TTW, it probably does not add much value, but I could see it demoralizing older, newer cubers.