### PR TITLE
Mobile style improvements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -68,7 +68,8 @@ html, body {
   margin: 15vh auto;
   padding: 20px;
   border: 1px solid #888;
-  width: 40%;
+
+  @apply max-w-sm;
 }
 
 .phx-modal-close {

--- a/lib/cuberacer_live_web/templates/layout/app.html.heex
+++ b/lib/cuberacer_live_web/templates/layout/app.html.heex
@@ -1,5 +1,5 @@
-<main>
-  <p class="alert alert-info mt-5 mx-auto w-96 text-center" role="alert"><%= get_flash(@conn, :info) %></p>
-  <p class="alert alert-danger mt-5 mx-auto w-96 text-center" role="alert"><%= get_flash(@conn, :error) %></p>
+<main class="px-4">
+  <p class="alert alert-info mt-5 mx-auto max-w-sm text-center" role="alert"><%= get_flash(@conn, :info) %></p>
+  <p class="alert alert-danger mt-5 mx-auto max-w-sm text-center" role="alert"><%= get_flash(@conn, :error) %></p>
   <%= @inner_content %>
 </main>

--- a/lib/cuberacer_live_web/templates/layout/live.html.heex
+++ b/lib/cuberacer_live_web/templates/layout/live.html.heex
@@ -1,9 +1,9 @@
 <main class="h-full">
-  <p class="alert alert-info mt-6 mx-6 w-96" role="alert"
+  <p class="alert alert-info mt-6 mx-6 max-w-sm" role="alert"
     phx-click="lv:clear-flash"
     phx-value-key="info"><%= live_flash(@flash, :info) %></p>
 
-  <p class="alert alert-danger mt-6 mx-6 w-96" role="alert"
+  <p class="alert alert-danger mt-6 mx-6 max-w-sm" role="alert"
     phx-click="lv:clear-flash"
     phx-value-key="error"><%= live_flash(@flash, :error) %></p>
 

--- a/lib/cuberacer_live_web/templates/user_confirmation/edit.html.heex
+++ b/lib/cuberacer_live_web/templates/user_confirmation/edit.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold text-center mb-6">Account confirmation</h1>
 
   <.form let={_f} for={:user} action={Routes.user_confirmation_path(@conn, :update, @token)}>

--- a/lib/cuberacer_live_web/templates/user_confirmation/new.html.heex
+++ b/lib/cuberacer_live_web/templates/user_confirmation/new.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold text-center mb-6">Resend confirmation instructions</h1>
 
   <div class="w-full bg-gray-200 border border-gray-600 rounded-lg p-3">

--- a/lib/cuberacer_live_web/templates/user_profile/show.html.heex
+++ b/lib/cuberacer_live_web/templates/user_profile/show.html.heex
@@ -1,4 +1,4 @@
-<div class="sm:grid sm:grid-cols-5 sm:gap-4 max-w-4xl mx-auto my-6 px-6">
+<div class="sm:grid sm:grid-cols-5 sm:gap-4 max-w-4xl mx-auto my-6">
   <div class="col-span-2">
     <h1 id="profile-username" class="text-4xl font-semibold"><%= @user.username %></h1>
 

--- a/lib/cuberacer_live_web/templates/user_registration/new.html.heex
+++ b/lib/cuberacer_live_web/templates/user_registration/new.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <div class="text-center mb-6">
     <h1 class="text-3xl font-semibold">Welcome</h1>
     <p>Create an account</p>

--- a/lib/cuberacer_live_web/templates/user_reset_password/edit.html.heex
+++ b/lib/cuberacer_live_web/templates/user_reset_password/edit.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold text-center mb-6">Reset password</h1>
 
   <div class="w-full bg-gray-200 border border-gray-600 rounded-lg p-3">

--- a/lib/cuberacer_live_web/templates/user_reset_password/new.html.heex
+++ b/lib/cuberacer_live_web/templates/user_reset_password/new.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold text-center mb-6">Forgot your password?</h1>
 
   <div class="w-full bg-gray-200 border border-gray-600 rounded-lg p-3">

--- a/lib/cuberacer_live_web/templates/user_session/new.html.heex
+++ b/lib/cuberacer_live_web/templates/user_session/new.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold text-center mb-6">Log in to Cuberacer</h1>
 
   <div class="w-full bg-gray-200 border border-gray-600 rounded-lg p-3">

--- a/lib/cuberacer_live_web/templates/user_settings/edit.html.heex
+++ b/lib/cuberacer_live_web/templates/user_settings/edit.html.heex
@@ -1,4 +1,4 @@
-<div class="w-96 m-auto my-6">
+<div class="max-w-sm m-auto my-6">
   <h1 class="text-3xl font-semibold mb-2">Settings</h1>
 
   <hr />


### PR DESCRIPTION
- There were `w-96`s scattered around the application, which was too narrow for an iPhone SE screen. This is fixed by using `max-w-sm`, which gives the same width.
- The narrow mobile New Room modal is improved.