### PR TITLE
RoomServer transient state

### DIFF
--- a/lib/cuberacer_live/accounts.ex
+++ b/lib/cuberacer_live/accounts.ex
@@ -79,6 +79,29 @@ defmodule CuberacerLive.Accounts do
   def get_user!(id), do: Repo.get!(User, id)
 
   @doc """
+  Gets a list of users, given a list of user IDs.
+
+  The returned list is not guaranteed to maintain the same session
+  order as the given list.
+
+  If a user ID does not exist, no such user is included
+  in the returned list.
+
+  ## Examples
+
+      iex> get_users([1, 2, 3])
+      [%User{}, %User{}, %User]
+
+      iex> get_users([123, 456])
+      [%User{id: 123}]
+
+  """
+  def get_users(ids) do
+    query = from u in User, where: u.id in ^ids
+    Repo.all(query)
+  end
+
+  @doc """
   Get a map of user IDs to user struct for the user IDs in `ids`.
 
   If an item of `ids` is not a valid user ID, a corresponding key

--- a/lib/cuberacer_live_web/live/game_live/room.html.heex
+++ b/lib/cuberacer_live_web/live/game_live/room.html.heex
@@ -1,7 +1,7 @@
 <div
   class="flex flex-row h-full relative"
   x-data="room"
-  x-init={"initializeRoom(#{length(@present_users)})"}
+  x-init={"initializeRoom(#{Enum.count(@participant_data)})"}
   @resize.window="calibratePagination"
 >
   <button
@@ -62,7 +62,7 @@
       <div class="flex flex-row h-full">
         <div class="flex flex-col justify-between border-r">
           <.stats stats={@stats} />
-          <.presence num_present_users={length(@present_users)} />
+          <.presence num_present_users={Enum.count(@participant_data)} />
         </div>
 
         <div
@@ -76,7 +76,7 @@
         </div>
 
         <div class="flex-1 h-full overflow-auto">
-          <.times_table users={@present_users} current_round={@current_round} past_rounds={@past_rounds} users_solving={@users_solving} />
+          <.times_table participant_data={@participant_data} current_round={@current_round} past_rounds={@past_rounds} />
         </div>
 
         <div


### PR DESCRIPTION
This PR adds transient state to `RoomServer`. For this PR, it is used to track if a user is currently solving, and if they are using keyboard input. This allows these pieces of data to be known when a user first enters the room, as opposed to before, where "Solving..." was just a broadcasted message, so if a user was not in the room for it, they would not know a user was currently solving when they entered.