### PR TITLE
Don't set usersPage to less than 1

### DIFF
--- a/assets/js/room.js
+++ b/assets/js/room.js
@@ -76,7 +76,7 @@
 
     this.usersPerPage = Math.floor(timesTableWidth / cellWidth);
 
-    if (this.usersPage > this.numUsersPages) {
+    if (this.numUsersPages > 0 && this.usersPage > this.numUsersPages) {
       this.usersPage = this.numUsersPages;
     }
   }


### PR DESCRIPTION
Sometimes, upon first entering a room, the times table would be empty. This was because Presence would not have registered the user that just joined the room yet, so the number of users would be 0, and the conditional changed in this PR would set the users page to 0 because that was the number of pages. However, there should never be a case where someone is in the room and there are 0 pages, so this conditional is edited to not do this when the current user hasn't been taken into account.