### PR TITLE
Bottom bar absolute positioning

### DIFF
--- a/assets/js/room.js
+++ b/assets/js/room.js
@@ -2,8 +2,58 @@
  * Room frontend state, for Alpine x-data directive.
  */
 
- export default () => ({
+const BottomBarStates = {
+  NORMAL: Symbol('normal'),
+  FULL: Symbol('full'),
+  COLLAPSED: Symbol('collapsed')
+};
+
+export default () => ({
   mobileChatOpen: false,
+  bottomBarState: BottomBarStates.NORMAL,
+  bottomBarTapped: null,
+
+  bottomBarFull() {
+    this.toggleBetweenBottomBarStates(BottomBarStates.NORMAL, BottomBarStates.FULL);
+  },
+
+  bottomBarCollapse() {
+    this.toggleBetweenBottomBarStates(BottomBarStates.NORMAL, BottomBarStates.COLLAPSED);
+  },
+
+  toggleBetweenBottomBarStates(state1, state2) {
+    if (this.bottomBarState === state2) {
+      this.bottomBarState = state1;
+    } else {
+      this.bottomBarState = state2;
+    }
+  },
+
+  get bottomRowHeight() {
+    switch (this.bottomBarState) {
+      case BottomBarStates.NORMAL: return 'h-60';
+      case BottomBarStates.FULL: return 'h-full';
+      case BottomBarStates.COLLAPSED: return '';
+    }
+  },
+
+  get bottomBarShow() {
+    return this.bottomBarState != BottomBarStates.COLLAPSED;
+  },
+
+  handleBottomBarTap() {
+    if (!this.bottomBarTapped) {
+      // First tap
+      this.bottomBarTapped = setTimeout(() => {
+        this.bottomBarTapped = null
+      }, 300);
+    } else {
+      // Second tap
+      clearTimeout(this.bottomBarTapped);
+      this.bottomBarTapped = null
+      this.bottomBarFull();
+    }
+  },
 
   addTouchPropagationStoppers() {
     this.$el.querySelectorAll('button').forEach(
@@ -80,4 +130,4 @@
       this.usersPage = this.numUsersPages;
     }
   }
- });
+});

--- a/lib/cuberacer_live_web/live/game_live/components.ex
+++ b/lib/cuberacer_live_web/live/game_live/components.ex
@@ -138,7 +138,7 @@ defmodule CuberacerLiveWeb.GameLive.Components do
           <th class="flex-1 border-y"></th>
         </tr>
       </thead>
-      <tbody id="times-table-body" class="bg-white" phx-update="prepend">
+      <tbody id="times-table-body" class="bg-white" x-show="bottomBarShow" phx-update="prepend">
         <%# Current round %>
         <tr id={"round-#{@current_round.id}"} class="flex t_round-row" title={@current_round.scramble}>
           <%= for {{user_id, data}, i} <- Enum.with_index(@participant_data) do %>
@@ -185,16 +185,20 @@ defmodule CuberacerLiveWeb.GameLive.Components do
   end
 
   def stats(assigns) do
+    # Taps into 'room' Alpine data
     ~H"""
     <table class="w-full" id="stats">
-      <thead class="bg-gray-50">
+      <thead class="bg-gray-50" @touchstart="handleBottomBarTap" @dblclick="bottomBarFull">
         <tr>
           <th scope="col" class="border-y px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-            Stats
+            <span class="inline-block mr-1" @click="bottomBarCollapse">
+              <i class="fas" :class="bottomBarShow ? 'fa-chevron-circle-down' : 'fa-chevron-circle-up'"></i>
+            </span>
+            <span>Stats</span>
           </th>
         </tr>
       </thead>
-      <tbody class="bg-white">
+      <tbody class="bg-white" x-show="bottomBarShow">
         <tr>
           <td class="px-6 whitespace-nowrap">ao5: <span class="t_ao5"><%= Sessions.display_stat(@stats.ao5) %></span></td>
         </tr>
@@ -209,7 +213,7 @@ defmodule CuberacerLiveWeb.GameLive.Components do
   def presence(assigns) do
     # Taps into 'room' Alpine data
     ~H"""
-    <table class="w-full mb-4">
+    <table class="w-full mb-4" x-show="bottomBarShow">
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="border-y px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">

--- a/lib/cuberacer_live_web/live/game_live/room.html.heex
+++ b/lib/cuberacer_live_web/live/game_live/room.html.heex
@@ -11,9 +11,9 @@
     <i class="relative fas fa-comment"></i>
   </button>
 
-  <div class="flex-1 flex flex-col" x-show="!mobileChatOpen">
+  <div class="relative flex-1" x-show="!mobileChatOpen">
     <div
-      class="p-4 static sm:relative"
+      class="h-full p-4 static sm:relative overflow-auto"
       id="timer-area"
       x-data="timer"
       @keydown.space.window="handlePointDown"
@@ -41,7 +41,7 @@
         </button>
       </div>
 
-      <div class="my-3 mx-auto text-center">
+      <div class="mt-3 mb-9 mx-auto text-center">
         <div class={"#{scramble_text_size(@current_round.scramble)} #{if @current_solve, do: "text-gray-300", else: "text-gray-900"}"}>
           <span class="t_scramble"><%= @current_round.scramble %></span>
         </div>
@@ -58,7 +58,7 @@
       </div>
     </div>
 
-    <div class="flex-1 overflow-auto">
+    <div class="absolute bottom-0 inset-x-0 w-full overflow-auto bg-white" :class="bottomRowHeight">
       <div class="flex flex-row h-full">
         <div class="flex flex-col justify-between border-r">
           <.stats stats={@stats} />


### PR DESCRIPTION
Also includes collapse and full height table functionality.

- To toggle collapse, click the circle arrow to the left of "Stats"
- To toggle full height, double click/tap the "Stats" header, outside of the circle arrow