### PR TITLE
Fix double submit bug

### DIFF
--- a/assets/js/timer.js
+++ b/assets/js/timer.js
@@ -44,10 +44,10 @@ export default () => ({
   },
 
   handlePointDown() {
-    if (!this.$store.inputFocused && !this.hasCurrentSolve) {
+    if (!this.$store.inputFocused) {
       if (this.interval) {
         this.stopTime();
-      } else if (!this.readyTimeout) {
+      } else if (!this.readyTimeout && !this.hasCurrentSolve) {
         this.readyTimeout = setTimeout(() => {
           this.resetTime();
           this.ready = true;

--- a/lib/cuberacer_live_web/live/game_live/room.html.heex
+++ b/lib/cuberacer_live_web/live/game_live/room.html.heex
@@ -47,7 +47,7 @@
       </div>
 
       <div class="mt-3 mb-9 mx-auto text-center">
-        <div class={"#{scramble_text_size(hd(@all_rounds).scramble)} #{if @current_solve, do: "text-gray-300", else: "text-gray-900"}"}>
+        <div class={"t_scramble-container #{scramble_text_size(hd(@all_rounds).scramble)} #{if @current_solve, do: "text-gray-300", else: "text-gray-900"}"}>
           <span class="t_scramble"><%= hd(@all_rounds).scramble %></span>
         </div>
         <div class="text-6xl my-4">


### PR DESCRIPTION
A user could submit a time for a round from two windows and cause a server-side error (https://github.com/gcpreston/cuberacer_live/issues/108). This was possible because `room` relied on the `current_solve` assign being set in the event handler, but only the window that submitted the first time gets the event handler called.