### PR TITLE
Fix 1 user 2 windows leave bug

### DIFF
--- a/lib/cuberacer_live/accounts.ex
+++ b/lib/cuberacer_live/accounts.ex
@@ -81,29 +81,6 @@ defmodule CuberacerLive.Accounts do
   def get_user!(id), do: Repo.get!(User, id)
 
   @doc """
-  Gets a list of users, given a list of user IDs.
-
-  The returned list is not guaranteed to maintain the same session
-  order as the given list.
-
-  If a user ID does not exist, no such user is included
-  in the returned list.
-
-  ## Examples
-
-      iex> get_users([1, 2, 3])
-      [%User{}, %User{}, %User]
-
-      iex> get_users([123, 456])
-      [%User{id: 123}]
-
-  """
-  def get_users(ids) do
-    query = from u in User, where: u.id in ^ids
-    Repo.all(query)
-  end
-
-  @doc """
   Get a map of user IDs to user struct for the user IDs in `ids`.
 
   If an item of `ids` is not a valid user ID, a corresponding key

--- a/lib/cuberacer_live/game/lobby_server.ex
+++ b/lib/cuberacer_live/game/lobby_server.ex
@@ -63,7 +63,7 @@ defmodule CuberacerLive.LobbyServer do
 
   @impl true
   def handle_continue(:tell_game_lobby_to_fetch, state) do
-    Phoenix.PubSub.broadcast!(CuberacerLive.PubSub, @game_lobby_topic, :fetch)
+    Phoenix.PubSub.local_broadcast(CuberacerLive.PubSub, @game_lobby_topic, :fetch)
     {:noreply, state}
   end
 

--- a/lib/cuberacer_live_web/presence.ex
+++ b/lib/cuberacer_live_web/presence.ex
@@ -5,11 +5,40 @@ defmodule CuberacerLiveWeb.Presence do
 
   alias CuberacerLive.Accounts
 
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
   def fetch(_topic, presences) do
     users = presences |> Map.keys() |> Accounts.get_users_map()
 
     for {key, %{metas: metas}} <- presences, into: %{} do
       {key, %{metas: metas, user: users[String.to_integer(key)]}}
     end
+  end
+
+  def handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state) do
+    for {user_id, presence} <- joins do
+      user_data = %{user: presence.user, metas: Map.fetch!(presences, user_id)}
+      msg = {CuberacerLive.PresenceClient, {:join, user_data}}
+      Phoenix.PubSub.local_broadcast(CuberacerLive.PubSub, topic, msg)
+    end
+
+    for {user_id, presence} <- leaves do
+      metas =
+        case Map.fetch(presences, user_id) do
+          {:ok, presence_metas} -> presence_metas
+          :error -> []
+        end
+
+      # only broadcast leave if a user has left on all windows/devices
+      if metas == [] do
+        user_data = %{user: presence.user, metas: metas}
+        msg = {CuberacerLive.PresenceClient, {:leave, user_data}}
+        Phoenix.PubSub.local_broadcast(CuberacerLive.PubSub, topic, msg)
+      end
+    end
+
+    {:ok, state}
   end
 end

--- a/test/cuberacer_live/game/room_server_test.exs
+++ b/test/cuberacer_live/game/room_server_test.exs
@@ -1,6 +1,7 @@
 defmodule CuberacerLive.RoomServerTest do
   use CuberacerLive.DataCase, async: false
 
+  alias CuberacerLive.ParticipantDataEntry
   alias CuberacerLive.{Events, RoomServer, Sessions, Messaging}
   alias CuberacerLive.Messaging.RoomMessage
   alias CuberacerLive.Sessions.Solve
@@ -49,10 +50,7 @@ defmodule CuberacerLive.RoomServerTest do
     test "allows creation of new round after a solve is submitted", %{pid: pid} do
       user = user_fixture()
 
-      send(pid, %Phoenix.Socket.Broadcast{
-        event: "presence_diff",
-        payload: %{joins: %{user.id => user}, leaves: %{}}
-      })
+      send(pid, {CuberacerLive.PresenceClient, {:join, ParticipantDataEntry.new(user)}})
 
       assert %Solve{} = RoomServer.create_solve(pid, user, 15341, :OK)
       assert is_binary(RoomServer.create_round(pid))


### PR DESCRIPTION
Previously, when a user joined a room from 2 windows and then left the room on one, it would show them as gone from the session on the other window (and for other users as well).

This PR fixes this by streamlining the presence events being sent and handled by various clients